### PR TITLE
fix: remove fdescribe from tests

### DIFF
--- a/ProjectPhoenix/ClientApp/src/api-authorization/authorize.service.spec.ts
+++ b/ProjectPhoenix/ClientApp/src/api-authorization/authorize.service.spec.ts
@@ -4,7 +4,7 @@ import { AuthorizeService } from './authorize.service';
 
 
 
-fdescribe('AuthorizeService', () => {
+describe('AuthorizeService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [AuthorizeService]

--- a/ProjectPhoenix/ClientApp/src/api-authorization/login-menu/login-menu.component.spec.ts
+++ b/ProjectPhoenix/ClientApp/src/api-authorization/login-menu/login-menu.component.spec.ts
@@ -3,7 +3,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { LoginMenuComponent } from './login-menu.component';
 
-fdescribe('LoginMenuComponent', () => {
+describe('LoginMenuComponent', () => {
   let component: LoginMenuComponent;
   let fixture: ComponentFixture<LoginMenuComponent>;
 


### PR DESCRIPTION
This PR removes the fdescribes from two test suites.