### PR TITLE
fix: removed app insights config data from appsettings.json

### DIFF
--- a/ProjectPhoenix/appsettings.json
+++ b/ProjectPhoenix/appsettings.json
@@ -16,8 +16,6 @@
       }
     }
   },
-  "AllowedHosts": "*",
-  "ApplicationInsights": {
-    "ConnectionString": "InstrumentationKey=6d53a652-831e-4930-954f-49725e134b6c;IngestionEndpoint=https://eastus2-0.in.applicationinsights.azure.com/"
-  }
+  "AllowedHosts": "*"
+  
 }


### PR DESCRIPTION
This PR removes the config data from appsettings.json for Application Insights.  The actual instrumentation key that I use was in it and I removed both the resource in the cloud and this key.